### PR TITLE
Implement TryCryptoRng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,16 @@ dependencies = [
  "hex",
  "hex_lit",
  "hmac",
+ "rand_core",
  "sha1",
  "sha2",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 
 [[package]]
 name = "sha1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ sha2 = { version = "0.10", default-features = false, optional = true }
 hmac = { version = "0.12", optional = true, features = ["reset"] }
 aes = { version = "0.8", optional = true }
 des = { version = "0.8", optional = true }
+rand_core = "0.9.3"
 
 [dev-dependencies]
 hex = "0.4"


### PR DESCRIPTION
This MR looks at implementing a more standard RNG API via the TryCryptoRng trait from rand_core.